### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/sync-secrets.yml
+++ b/.github/workflows/sync-secrets.yml
@@ -14,7 +14,7 @@ jobs:
   sync-secrets:
     runs-on: ubuntu-latest
     steps:
-      - uses: google/secrets-sync-action@v1.4.1
+      - uses: jpoehnelt/secrets-sync-action@v1.4.1
         with:
           SECRETS: |
             ^(MODRINTH|CURSEFORGE)_TOKEN$


### PR DESCRIPTION
This is a PR to update the action to the new repository location from https://github.com/google/secrets-sync-action to https://github.com/jpoehnelt/secrets-sync-action. Note that GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.